### PR TITLE
Add Read Group method

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ odoo.search_read('product.product', params, context)
 .catch(e => { /* ... */ })
 ```
 
+**Read Group**
+Just like the Search & read, but get the list of records in list view grouped by the given ``groupby`` fields.
+If ``lazy`` true, the results are only grouped by the first groupby and the remaining groupbys are put in the __context key.  
+If ``lazy`` false, all the groupbys are done in one call.
+Returns a promised which resolves to an array of results matching the parameters provided.
+Array containing: all the values of fields grouped by the fields in ``groupby`` argument, 
+``__domain``: array of list specifying the search criteria, ``__context``: array with argument like ``groupby``
+```js
+const  params = {
+  domain: [ ["project_id", "=", 7] ],
+  fields: [ "color", "stage_id" , "sequence"],
+  groupby: [
+    "stage_id"
+  ],
+  order:  'sequence',
+  lazy: true
+}
+
+odoo.read_group('project.task', params, context)
+.then(response => { /* ... */ })
+.catch(e => { /* ... */ })
+```
+
 **Create**
 Receives a `model` string and a `params` object with properties corresponding to the fields you want to write in the row.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,22 @@ Odoo.prototype.get = function (model, params, context) {
   })
 }
 
+// Read Group
+Odoo.prototype.read_group = function(model, params, context) {
+  return this._request("/web/dataset/call_kw", {
+    model: model,
+    method: "read_group",
+    args: [],
+    kwargs: {
+      context: { ...this.context, ...context },
+      domain: params.domain,
+      fields: params.fields,
+      groupby: params.groupby,
+      lazy: params.lazy,
+      orderby: params.order
+    },
+  })
+}
 
 // Browse records by ID
 // Not a direct implementation of Odoo RPC 'browse' but rather a workaround based on 'search_read'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-odoo-promise-based",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "React Native library for Odoo using Fetch API and JSON-RPC",
   "keywords": [
     "odoo",
@@ -36,6 +36,10 @@
     {
       "name": "Nichita Gruia",
       "email": "gruianichita@gmail.com"
+    },
+    {
+      "name": "Aidos Kakimzhanov",
+      "email": "aidos.kakimzhan@gmail.com"
     }
   ]
 }


### PR DESCRIPTION
**For Read Group**

If your need group of Stage in tasks you can use it! 😉

```
const  params = {
  domain: [ ["project_id", "=", 7] ],
  fields: [ "color", "stage_id" , "sequence"],
  groupby: [
    "stage_id"
  ],
  order:  'sequence',
  lazy: true
}

odoo.read_group('project.task', params, context)
.then(response => { /* ... */ })
.catch(e => { /* ... */ })
```

https://github.com/odoo/odoo/blob/11.0/odoo/models.py#L1880